### PR TITLE
Feature/back/#1

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -40,7 +40,6 @@ out/
 .vscode/
 
 # Configuration files (환경설정 파일)
-application.yml
 application-*.yml
 *.env
 .env.*

--- a/back/README.md
+++ b/back/README.md
@@ -1,0 +1,120 @@
+## 📌 프로젝트 개요
+
+"아무 말 대잔치" 커뮤니티 백엔드 구현 입니다.
+
+### 🔗 프론트엔드 레포지토리 링크
+
+[FrontEnd](https://github.com/100-hours-a-week/2-logan-jo-week-coumunity)
+
+### 🛠️ 기술 스택
+
+<img src="https://img.shields.io/badge/Spring Boot-green?style=for-the-badge&logo=기술스택아이콘&logoColor=white">
+
+## 📌 폴더 구조
+
+```
+📦back
+ ┣ 📂config
+ ┃ ┣ 📂jwt
+ ┃ ┃ ┣ 📜JwtAuthenticationFilter.java
+ ┃ ┃ ┗ 📜JwtUtil.java
+ ┃ ┣ 📜SecurityConfig.java
+ ┃ ┣ 📜SwaggerConfig.java
+ ┃ ┗ 📜WebConfig.java
+ ┣ 📂controller
+ ┃ ┣ 📜CommentController.java
+ ┃ ┣ 📜PostController.java
+ ┃ ┣ 📜RootController.java
+ ┃ ┣ 📜TokenController.java
+ ┃ ┗ 📜UserController.java
+ ┣ 📂dto
+ ┃ ┣ 📂Comment
+ ┃ ┃ ┣ 📜CommentCreateRequest.java
+ ┃ ┃ ┣ 📜CommentDto.java
+ ┃ ┃ ┗ 📜CommentUserInfo.java
+ ┃ ┣ 📂Post
+ ┃ ┃ ┣ 📜PostCreateRequest.java
+ ┃ ┃ ┗ 📜PostDto.java
+ ┃ ┣ 📂Token
+ ┃ ┃ ┣ 📜TokenDto.java
+ ┃ ┃ ┗ 📜TokenResponse.java
+ ┃ ┣ 📂User
+ ┃ ┃ ┣ 📜UserCreateRequest.java
+ ┃ ┃ ┣ 📜UserDto.java
+ ┃ ┃ ┣ 📜UserLoginRequest.java
+ ┃ ┃ ┣ 📜UserPasswordUpdateRequest.java
+ ┃ ┃ ┗ 📜UserUpdateRequest.java
+ ┃ ┗ 📜Response.java
+ ┣ 📂entity
+ ┃ ┣ 📜Comment.java
+ ┃ ┣ 📜Post.java
+ ┃ ┣ 📜RefreshToken.java
+ ┃ ┗ 📜User.java
+ ┣ 📂exception
+ ┃ ┣ 📂code
+ ┃ ┃ ┣ 📜ConflictException.java
+ ┃ ┃ ┣ 📜ForbiddenException.java
+ ┃ ┃ ┣ 📜NotFoundException.java
+ ┃ ┃ ┗ 📜UnauthorizedException.java
+ ┃ ┣ 📜ErrorResponse.java
+ ┃ ┗ 📜GlobalExceptionHandler.java
+ ┣ 📂repository
+ ┃ ┣ 📜CommentRepository.java
+ ┃ ┣ 📜PostRepository.java
+ ┃ ┣ 📜RefreshTokenRepository.java
+ ┃ ┗ 📜UserRepository.java
+ ┣ 📂service
+ ┃ ┣ 📜CommentService.java
+ ┃ ┣ 📜ImageUploadService.java
+ ┃ ┣ 📜PostService.java
+ ┃ ┣ 📜TokenService.java
+ ┃ ┗ 📜UserService.java
+ ┣ 📂util
+ ┃ ┣ 📂message
+ ┃ ┃ ┣ 📜ErrorMessage.java
+ ┃ ┃ ┗ 📜SuccessMessage.java
+ ┃ ┗ 📜ApiResponse.java
+ ┗ 📜BackApplication.java
+```
+
+## 📌 구현 기능
+
+| 기능 및 동작     | 파일명                         | 설명                                               |
+|-------------|-----------------------------|--------------------------------------------------|
+| 웹 기본 설정     | WebConfig.java              | CORS설정, 쿠키 설정 등 웹 설정                             |
+| API 문서화     | SwaggerConfig.java          | Swagger를 사용해 API 문서화                             |
+| 보안 검사       | SecurityConfig.java         | 웹 보안 검사                                          | 
+| 유저 인증인가 처리  | jwtAuthentication.java      | `JwtUtil` 을 사용해 유저가 Authorization 토큰을 가지고 있는지 검사 |
+| 전역 에러처리 로직  | GlobalExceptionHandler.java | 컨트롤러에서 발생하는 전역에러 처리                              |
+| 최상위 컨트롤러    | RootController.java         | 최상위 컨트롤러로, 서버가 정상적으로 작동하는지 확인하는 엔드포인트            |
+| 유저 컨트롤러     | UserController.java         | 유저 관련 API 엔드포인트를 관리하는 컨트롤러                       |
+| 토큰 컨트롤러     | TokenController.java        | 토큰 관련 API 엔드포인트를 관리하는 컨트롤러                       |
+| 게시글 컨트롤러    | PostController.java         | 게시글 관련 API 엔드포인트를 관리하는 컨트롤러                      |
+| 댓글 컨트롤러     | CommentController.java      | 댓글 관련 API 엔드포인트를 관리하는 컨트롤러                       |
+| 유저 서비스      | UserService.java            | 유저 관련 비즈니스 로직을 처리하는 서비스                          |
+| 토큰 서비스      | TokenService.java           | 토큰 관련 비즈니스 로직을 처리하는 서비스                          |
+| 게시글 서비스     | PostService.java            | 게시글 관련 비즈니스 로직을 처리하는 서비스                         |
+| 이미지 업로드 서비스 | ImageUploadService.java     | `ImageBB`를 사용한 이미지 업로드 관련 비즈니스 로직을 처리하는 서비스      |
+| 댓글 서비스      | CommentService.java         | 댓글 관련 비즈니스 로직을 처리하는 서비스                          |
+| DTO         | fileName + DTO.java         | 엔티티와 컨트롤러 사이의 데이터 전달을 위한 DTO 객체                  |
+| 엔티티         | fileName.java               | 데이터베이스와 연동되는 엔티티 객체                              |
+| 레포지토리       | fileNameRepository.java     | 데이터베이스와 연동되는 레포지토리 객체                            |
+
+## 📌 회고
+
+### 1. refreshToken의 재발급 로직 문제
+
+백엔드에서 body로 accessToken을 발급받고 재발급을 테스트했을때는 정상적으로 동작했지만, 클라이언트로 httpOnly속성의 쿠리를 전달하고, 전달받아서
+재발급 하도록 로직을 변경 한 이후, 재발급되지 않는 문제가 존재했습니다.
+추가적인 방법을 조사하던 중, httpOnly속성의 쿠키를 사용하는것 이외에 Redis를 사용해서 토큰을 저장하고, 일부 key값만 전달해서 토큰을 재발급
+하는 방법도 있다는 것을 알게 되었다. 추후에는 Redis를 사용해서 토큰을 저장하고, 재발급하는 방법을 사용해야 할 것 같다.
+
+### 2. 이미지 업로드 로직
+
+현재는 imageBB를 이용해서 처리하지만, 추후 AWS로 배포가 될 경우, S3를 사용해서 배포되도록 개선이 필요하다. 현재는 iamgeBB를 사용해서 저장,
+url 경로 반환도 가능하지만, 매우 느리게 동작하고, 용량이 큰 상태로 저장하면서 성능저하의 문제가 존재한다. S3를 사용해서 저장하는 방식으로 개선할 예정이다.
+
+### 3. 테스트 코드 작성
+
+구체적인 테스트코드가 존재하지 않습니다. JUnit을 통한 테스트 추가가 필요합니다. 추가적으로 Swagger의 문서에 작성된 오류와 예외에 대해
+명확히 작성할 필요가 있습니다.

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.example'
+group = 'KBT2.comunity'
 version = '0.0.1-SNAPSHOT'
 
 java {

--- a/back/src/main/java/KBT2/comunity/back/BackApplication.java
+++ b/back/src/main/java/KBT2/comunity/back/BackApplication.java
@@ -1,4 +1,4 @@
-package com.example.back;
+package KBT2.comunity.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package KBT2.comunity.back.config;
+
+import KBT2.comunity.back.config.jwt.JwtAuthenticationFilter;
+import KBT2.comunity.back.config.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtUtil);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**",
+                                "/error"
+                        ).permitAll()
+                        .requestMatchers("/", "/health", "/users/signup", "/users/login", "/users/refresh").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+
+        return http.build();
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserService userService;
+
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
         return new JwtAuthenticationFilter(jwtUtil, userService);
@@ -30,13 +31,11 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/swagger-resources/**",
-                                "/webjars/**",
-                                "/error"
+                                "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
+                                "/swagger-resources/**", "/webjars/**",
+                                "/users/signup", "/users/login", "/users/refresh",
+                                "/error", "/health", "/"
                         ).permitAll()
-                        .requestMatchers("/", "/health", "/users/signup", "/users/login", "/users/refresh", "/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -16,16 +18,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtUtil jwtUtil;
-    private final UserService userService;
-
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtUtil, userService);
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -38,7 +37,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 
         return http.build();

--- a/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                                 "/webjars/**",
                                 "/error"
                         ).permitAll()
-                        .requestMatchers("/", "/health", "/users/signup", "/users/login", "/users/refresh").permitAll()
+                        .requestMatchers("/", "/health", "/users/signup", "/users/login", "/users/refresh", "/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package KBT2.comunity.back.config;
 
 import KBT2.comunity.back.config.jwt.JwtAuthenticationFilter;
 import KBT2.comunity.back.config.jwt.JwtUtil;
+import KBT2.comunity.back.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,9 +17,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
+    private final UserService userService;
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtUtil);
+        return new JwtAuthenticationFilter(jwtUtil, userService);
     }
 
     @Bean

--- a/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
                                 "/swagger-resources/**", "/webjars/**",
                                 "/users/signup", "/users/login", "/users/refresh",
-                                "/error", "/health", "/"
+                                "/error", "/health"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SecurityConfig.java
@@ -1,11 +1,10 @@
 package KBT2.comunity.back.config;
 
 import KBT2.comunity.back.config.jwt.JwtAuthenticationFilter;
-import KBT2.comunity.back.config.jwt.JwtUtil;
-import KBT2.comunity.back.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -29,6 +28,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // OPTIONS 허용
                         .requestMatchers(
                                 "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
                                 "/swagger-resources/**", "/webjars/**",

--- a/back/src/main/java/KBT2/comunity/back/config/SwaggerConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package KBT2.comunity.back.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "User API", version = "1.0", description = "User API Documentation"),
+        security = @SecurityRequirement(name = "BearerAuth")
+)
+@SecurityScheme(
+        name = "BearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class SwaggerConfig {
+}

--- a/back/src/main/java/KBT2/comunity/back/config/WebConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/WebConfig.java
@@ -1,0 +1,16 @@
+package KBT2.comunity.back.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(false);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/config/WebConfig.java
+++ b/back/src/main/java/KBT2/comunity/back/config/WebConfig.java
@@ -8,9 +8,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins("http://127.0.0.1:8080")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(false);
+                .allowedHeaders("Authorization", "Content-Type")
+                .allowCredentials(true);
     }
 }

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -28,12 +28,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (token != null && jwtUtil.validateToken(token)) {
+            jwtUtil.validateToken(token);
             UUID userId = jwtUtil.getUserIdFromToken(token);
 
             Authentication authentication = jwtUtil.getAuthentication(token, userId);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-
-            System.out.println("SecurityContextHolder에 인증 객체 설정 완료: " + authentication);
         } else {
             System.out.println("JWT 검증 실패 또는 토큰 없음");
         }

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -10,12 +10,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package KBT2.comunity.back.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (shouldNotFilter(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtUtil.validateToken(token)) {
+            UUID userId = jwtUtil.getUserIdFromToken(token);
+
+            Authentication authentication = jwtUtil.getAuthentication(token, userId);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            System.out.println("SecurityContextHolder에 인증 객체 설정 완료: " + authentication);
+        } else {
+            System.out.println("JWT 검증 실패 또는 토큰 없음");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package KBT2.comunity.back.config.jwt;
 
+import KBT2.comunity.back.dto.User.UserDto;
+import KBT2.comunity.back.service.UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +17,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
+    private final UserService userService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -31,10 +34,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             jwtUtil.validateToken(token);
             UUID userId = jwtUtil.getUserIdFromToken(token);
 
+            UserDto userDto = userService.getUser(userId);
+
+            if (userDto == null) {
+                System.out.println("JWT 검증 실패");
+                return;
+            }
+
             Authentication authentication = jwtUtil.getAuthentication(token, userId);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } else {
-            System.out.println("JWT 검증 실패 또는 토큰 없음");
+            System.out.println("토큰 없음");
         }
 
         filterChain.doFilter(request, response);

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final UserService userService;
 
     private static final List<String> EXCLUDED_PATHS = List.of(
-            "/", "/users/signup", "/users/login", "/users/refresh", "/auth/",
+            "/users/signup", "/users/login", "/users/refresh", "/auth/",
             "/swagger-ui/", "/swagger-ui.html", "/swagger-resources/",
             "/v3/api-docs", "/v3/api-docs/", "/webjars/", "/error", "/health"
     );
@@ -37,14 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-
-        if (shouldNotFilter(request)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         String token = resolveToken(request);
-        System.out.println(token);
 
         if (token == null) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, ErrorMessage.Token_NOT_FOUND);

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,7 @@
 package KBT2.comunity.back.config.jwt;
 
 import KBT2.comunity.back.dto.User.UserDto;
-import KBT2.comunity.back.exception.code.UnauthorizedException;
-import KBT2.comunity.back.exception.message.ErrorMessage;
+import KBT2.comunity.back.util.message.ErrorMessage;
 import KBT2.comunity.back.service.UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package KBT2.comunity.back.config.jwt;
 
 import KBT2.comunity.back.dto.User.UserDto;
+import KBT2.comunity.back.exception.code.UnauthorizedException;
+import KBT2.comunity.back.exception.message.ErrorMessage;
 import KBT2.comunity.back.service.UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,12 +14,25 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final UserService userService;
+
+    private static final List<String> EXCLUDED_PATHS = List.of(
+            "/", "/users/signup", "/users/login", "/users/refresh", "/auth/",
+            "/swagger-ui/", "/swagger-ui.html", "/swagger-resources/",
+            "/v3/api-docs", "/v3/api-docs/", "/webjars/", "/error", "/health"
+    );
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return EXCLUDED_PATHS.stream().anyMatch(path::startsWith);
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -29,23 +44,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String token = resolveToken(request);
+        System.out.println(token);
 
-        if (token != null && jwtUtil.validateToken(token)) {
-            jwtUtil.validateToken(token);
-            UUID userId = jwtUtil.getUserIdFromToken(token);
-
-            UserDto userDto = userService.getUser(userId);
-
-            if (userDto == null) {
-                System.out.println("JWT 검증 실패");
-                return;
-            }
-
-            Authentication authentication = jwtUtil.getAuthentication(token, userId);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        } else {
-            System.out.println("토큰 없음");
+        if (token == null) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, ErrorMessage.Token_NOT_FOUND);
+            return;
         }
+
+        try {
+            jwtUtil.validateToken(token);
+        } catch (Exception e) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, ErrorMessage.INVALID_TOKEN);
+            return;
+        }
+
+        UUID userId = jwtUtil.getUserIdFromToken(token);
+        UserDto userDto = userService.getUser(userId);
+
+        if (userDto == null) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, ErrorMessage.USER_NOT_FOUND);
+            return;
+        }
+
+        Authentication authentication = jwtUtil.getAuthentication(token, userId);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,8 @@
 package KBT2.comunity.back.config.jwt;
 
 import KBT2.comunity.back.dto.User.UserDto;
-import KBT2.comunity.back.util.message.ErrorMessage;
 import KBT2.comunity.back.service.UserService;
+import KBT2.comunity.back.util.message.ErrorMessage;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,6 +38,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+        if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = resolveToken(request);
 
         if (token == null) {

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtUtil.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtUtil.java
@@ -1,0 +1,64 @@
+package KBT2.comunity.back.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long accessTokenValidMillisecond = 1000 * 60 * 30;
+    private final long refreshTokenValidMillisecond = 1000 * 60 * 60 * 24;
+
+    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+    public String createAccessToken(UUID userId, String email) {
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidMillisecond))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+    public String createRefreshToken(UUID userId, String email) {
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidMillisecond))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+    public Claims parseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+    public boolean validateToken(String token) {
+        try {
+            parseToken(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+    public UUID getUserIdFromToken(String token) {
+        Claims claims = parseToken(token);
+        return UUID.fromString(claims.getSubject());
+    }
+    public UsernamePasswordAuthenticationToken getAuthentication(String token, UUID userId) {
+        return new UsernamePasswordAuthenticationToken(userId, token, null);
+    }
+
+}

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtUtil.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtUtil.java
@@ -1,9 +1,6 @@
 package KBT2.comunity.back.config.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
@@ -47,10 +44,23 @@ public class JwtUtil {
     }
     public boolean validateToken(String token) {
         try {
-            parseToken(token);
+            Claims claims = parseToken(token);
+            Date expiration = claims.getExpiration();
+
+            if (expiration.before(new Date())) {
+                throw new JwtException("만료된 토큰입니다.");
+            }
             return true;
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("만료된 토큰입니다.", e);
+        } catch (MalformedJwtException e) {
+            throw new JwtException("손상된 토큰입니다.", e);
+        } catch (SignatureException e) {
+            throw new JwtException("잘못된 서명입니다.", e);
+        } catch (IllegalArgumentException e) {
+            throw new JwtException("토큰이 비어있거나 잘못되었습니다.", e);
         } catch (JwtException e) {
-            return false;
+            throw new JwtException("유효하지 않은 토큰입니다.", e);
         }
     }
     public UUID getUserIdFromToken(String token) {

--- a/back/src/main/java/KBT2/comunity/back/config/jwt/JwtUtil.java
+++ b/back/src/main/java/KBT2/comunity/back/config/jwt/JwtUtil.java
@@ -1,5 +1,6 @@
 package KBT2.comunity.back.config.jwt;
 
+import KBT2.comunity.back.exception.code.UnauthorizedException;
 import io.jsonwebtoken.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -52,15 +53,15 @@ public class JwtUtil {
             }
             return true;
         } catch (ExpiredJwtException e) {
-            throw new JwtException("만료된 토큰입니다.", e);
+            throw new UnauthorizedException("만료된 토큰입니다.");
         } catch (MalformedJwtException e) {
-            throw new JwtException("손상된 토큰입니다.", e);
+            throw new UnauthorizedException("손상된 토큰입니다.");
         } catch (SignatureException e) {
-            throw new JwtException("잘못된 서명입니다.", e);
+            throw new UnauthorizedException("잘못된 서명입니다.");
         } catch (IllegalArgumentException e) {
-            throw new JwtException("토큰이 비어있거나 잘못되었습니다.", e);
+            throw new UnauthorizedException("토큰이 비어있거나 잘못되었습니다.");
         } catch (JwtException e) {
-            throw new JwtException("유효하지 않은 토큰입니다.", e);
+            throw new UnauthorizedException("유효하지 않은 토큰입니다.");
         }
     }
     public UUID getUserIdFromToken(String token) {

--- a/back/src/main/java/KBT2/comunity/back/controller/CommentController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/CommentController.java
@@ -1,0 +1,43 @@
+package KBT2.comunity.back.controller;
+
+import KBT2.comunity.back.dto.Comment.CommentCreateRequest;
+import KBT2.comunity.back.dto.Comment.CommentDto;
+import KBT2.comunity.back.dto.Response;
+import KBT2.comunity.back.service.CommentService;
+import KBT2.comunity.back.util.ApiResponse;
+import KBT2.comunity.back.util.message.SuccessMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/post/{postId}/comment")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping("")
+    public ApiResponse<Response> createComment(@PathVariable UUID postId, @Valid @RequestBody CommentCreateRequest request) {
+        return ApiResponse.ok(SuccessMessage.POST_SUCCESS, commentService.createComment(postId, request));
+    }
+    @GetMapping("")
+    public ApiResponse<List<CommentDto>> getCommentList(@PathVariable UUID postId) {
+        return ApiResponse.ok(SuccessMessage.FIND_SUCCESS, commentService.getCommentList(postId));
+    }
+    @GetMapping("/{commentId}")
+    public ApiResponse<CommentDto> getComment(@PathVariable UUID commentId) {
+        return ApiResponse.ok(SuccessMessage.FIND_SUCCESS, commentService.getComment(commentId));
+    }
+    @PatchMapping("/{commentId}")
+    public ApiResponse<CommentDto> updateComment(@PathVariable UUID commentId, @Valid @RequestBody CommentCreateRequest request) {
+        return ApiResponse.ok(SuccessMessage.PATCH_SUCCESS, commentService.updateComment(commentId, request));
+    }
+    @DeleteMapping("/{commentId}")
+    public ApiResponse<Response> deleteComment(@PathVariable UUID commentId) {
+        commentService.deleteComment(commentId);
+        return ApiResponse.ok(SuccessMessage.DELETE_SUCCESS);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/controller/CommentController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/CommentController.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/post/{postId}/comment")
+@RequestMapping("/posts/{postId}/comments")
 @RequiredArgsConstructor
 public class CommentController {
     private final CommentService commentService;
@@ -23,18 +23,22 @@ public class CommentController {
     public ApiResponse<Response> createComment(@PathVariable UUID postId, @Valid @RequestBody CommentCreateRequest request) {
         return ApiResponse.ok(SuccessMessage.POST_SUCCESS, commentService.createComment(postId, request));
     }
+
     @GetMapping("")
     public ApiResponse<List<CommentDto>> getCommentList(@PathVariable UUID postId) {
         return ApiResponse.ok(SuccessMessage.FIND_SUCCESS, commentService.getCommentList(postId));
     }
+
     @GetMapping("/{commentId}")
     public ApiResponse<CommentDto> getComment(@PathVariable UUID commentId) {
         return ApiResponse.ok(SuccessMessage.FIND_SUCCESS, commentService.getComment(commentId));
     }
+
     @PatchMapping("/{commentId}")
     public ApiResponse<CommentDto> updateComment(@PathVariable UUID commentId, @Valid @RequestBody CommentCreateRequest request) {
         return ApiResponse.ok(SuccessMessage.PATCH_SUCCESS, commentService.updateComment(commentId, request));
     }
+
     @DeleteMapping("/{commentId}")
     public ApiResponse<Response> deleteComment(@PathVariable UUID commentId) {
         commentService.deleteComment(commentId);

--- a/back/src/main/java/KBT2/comunity/back/controller/PostController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/PostController.java
@@ -1,0 +1,49 @@
+package KBT2.comunity.back.controller;
+
+import KBT2.comunity.back.dto.Post.PostCreateRequest;
+import KBT2.comunity.back.dto.Post.PostDto;
+import KBT2.comunity.back.dto.Post.PostResponse;
+import KBT2.comunity.back.service.PostService;
+import KBT2.comunity.back.util.ApiResponse;
+import KBT2.comunity.back.util.message.SuccessMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping("")
+    public ApiResponse<PostResponse> createPost(@AuthenticationPrincipal UUID userId, @Valid @RequestBody PostCreateRequest request) {
+        return ApiResponse.ok(SuccessMessage.POST_SUCCESS, postService.createPost(userId, request));
+    }
+    @GetMapping("")
+    public ApiResponse<List<PostDto>> getPostList(@AuthenticationPrincipal UUID userId) {
+        return ApiResponse.ok(SuccessMessage.FIND_SUCCESS, postService.getPostList(userId));
+    }
+    @GetMapping("/{postId}")
+    public ApiResponse<PostDto> getPost(@PathVariable UUID postId) {
+        return ApiResponse.ok(postService.getPost(postId));
+    }
+    @PatchMapping("/{postId}")
+    public ApiResponse<PostDto> updatePost(@PathVariable UUID postId, @Valid @RequestBody PostCreateRequest request) {
+        return ApiResponse.ok(SuccessMessage.PATCH_SUCCESS, postService.updatePost(postId, request));
+    }
+    @PatchMapping("/{postId}/like")
+    public ApiResponse<Void> addLike(@PathVariable UUID postId) {
+        postService.addLike(postId);
+        return ApiResponse.ok(SuccessMessage.PATCH_SUCCESS);
+    }
+    @DeleteMapping("/{postId}")
+    public ApiResponse<Void> deletePost(@PathVariable UUID postId) {
+        postService.deletePost(postId);
+        return ApiResponse.ok(SuccessMessage.DELETE_SUCCESS);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/controller/PostController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/PostController.java
@@ -2,7 +2,7 @@ package KBT2.comunity.back.controller;
 
 import KBT2.comunity.back.dto.Post.PostCreateRequest;
 import KBT2.comunity.back.dto.Post.PostDto;
-import KBT2.comunity.back.dto.Post.PostResponse;
+import KBT2.comunity.back.dto.Response;
 import KBT2.comunity.back.service.PostService;
 import KBT2.comunity.back.util.ApiResponse;
 import KBT2.comunity.back.util.message.SuccessMessage;
@@ -21,7 +21,7 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping("")
-    public ApiResponse<PostResponse> createPost(@AuthenticationPrincipal UUID userId, @Valid @RequestBody PostCreateRequest request) {
+    public ApiResponse<Response> createPost(@AuthenticationPrincipal UUID userId, @Valid @RequestBody PostCreateRequest request) {
         return ApiResponse.ok(SuccessMessage.POST_SUCCESS, postService.createPost(userId, request));
     }
     @GetMapping("")

--- a/back/src/main/java/KBT2/comunity/back/controller/PostController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/PostController.java
@@ -24,23 +24,28 @@ public class PostController {
     public ApiResponse<Response> createPost(@AuthenticationPrincipal UUID userId, @Valid @RequestBody PostCreateRequest request) {
         return ApiResponse.ok(SuccessMessage.POST_SUCCESS, postService.createPost(userId, request));
     }
+
     @GetMapping("")
-    public ApiResponse<List<PostDto>> getPostList(@AuthenticationPrincipal UUID userId) {
-        return ApiResponse.ok(SuccessMessage.FIND_SUCCESS, postService.getPostList(userId));
+    public ApiResponse<List<PostDto>> getPostList() {
+        return ApiResponse.ok(SuccessMessage.FIND_SUCCESS, postService.getPostList());
     }
+
     @GetMapping("/{postId}")
     public ApiResponse<PostDto> getPost(@PathVariable UUID postId) {
         return ApiResponse.ok(postService.getPost(postId));
     }
+
     @PatchMapping("/{postId}")
     public ApiResponse<PostDto> updatePost(@PathVariable UUID postId, @Valid @RequestBody PostCreateRequest request) {
         return ApiResponse.ok(SuccessMessage.PATCH_SUCCESS, postService.updatePost(postId, request));
     }
+
     @PatchMapping("/{postId}/like")
     public ApiResponse<Void> addLike(@PathVariable UUID postId) {
         postService.addLike(postId);
         return ApiResponse.ok(SuccessMessage.PATCH_SUCCESS);
     }
+
     @DeleteMapping("/{postId}")
     public ApiResponse<Void> deletePost(@PathVariable UUID postId) {
         postService.deletePost(postId);

--- a/back/src/main/java/KBT2/comunity/back/controller/PostController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/PostController.java
@@ -21,7 +21,7 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping("")
-    public ApiResponse<Response> createPost(@AuthenticationPrincipal UUID userId, @Valid @RequestBody PostCreateRequest request) {
+    public ApiResponse<Response> createPost(@AuthenticationPrincipal UUID userId, @Valid @ModelAttribute PostCreateRequest request) {
         return ApiResponse.ok(SuccessMessage.POST_SUCCESS, postService.createPost(userId, request));
     }
 
@@ -36,7 +36,7 @@ public class PostController {
     }
 
     @PatchMapping("/{postId}")
-    public ApiResponse<PostDto> updatePost(@PathVariable UUID postId, @Valid @RequestBody PostCreateRequest request) {
+    public ApiResponse<PostDto> updatePost(@PathVariable UUID postId, @Valid @ModelAttribute PostCreateRequest request) {
         return ApiResponse.ok(SuccessMessage.PATCH_SUCCESS, postService.updatePost(postId, request));
     }
 

--- a/back/src/main/java/KBT2/comunity/back/controller/RootController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/RootController.java
@@ -1,0 +1,14 @@
+package KBT2.comunity.back.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+public class RootController {
+    @GetMapping("/health")
+    public String healthCheck() {
+        return "Server is Running";
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/controller/TokenController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/TokenController.java
@@ -1,0 +1,37 @@
+package KBT2.comunity.back.controller;
+
+import KBT2.comunity.back.dto.Token.TokenDto;
+import KBT2.comunity.back.dto.Token.TokenResponse;
+import KBT2.comunity.back.entity.RefreshToken;
+import KBT2.comunity.back.repository.RefreshTokenRepository;
+import KBT2.comunity.back.service.TokenService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class TokenController {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenService tokenService;
+
+    @PostMapping("/token")
+    public ResponseEntity<TokenResponse> refreshAccessToken(@RequestBody String refreshToken, HttpServletResponse response) {
+        try {
+            Optional<RefreshToken> storedToken = refreshTokenRepository.findByToken(refreshToken);
+            RefreshToken token = storedToken.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰입니다."));
+
+            TokenDto tokenDto = tokenService.generateTokens(token.getUser());
+            return ResponseEntity.ok(new TokenResponse(tokenDto.getAccessToken()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/controller/TokenController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/TokenController.java
@@ -8,11 +8,7 @@ import KBT2.comunity.back.service.TokenService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
 @RestController

--- a/back/src/main/java/KBT2/comunity/back/controller/TokenController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/TokenController.java
@@ -8,7 +8,11 @@ import KBT2.comunity.back.service.TokenService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import java.util.Optional;
 
 @RestController
@@ -19,7 +23,7 @@ public class TokenController {
     private final TokenService tokenService;
 
     @PostMapping("/token")
-    public ResponseEntity<TokenResponse> refreshAccessToken(@RequestBody String refreshToken, HttpServletResponse response) {
+    public ResponseEntity<TokenResponse> refreshAccessToken(@CookieValue(value = "refreshToken", required = true) String refreshToken, HttpServletResponse response) {
         try {
             Optional<RefreshToken> storedToken = refreshTokenRepository.findByToken(refreshToken);
             RefreshToken token = storedToken.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰입니다."));

--- a/back/src/main/java/KBT2/comunity/back/controller/UserController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/UserController.java
@@ -18,9 +18,10 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<TokenResponse> signUp(@Valid @RequestBody UserCreateRequest request) {
+    public ResponseEntity<Void> signUp(@Valid @RequestBody UserCreateRequest request) {
         try{
-            return ResponseEntity.ok(userService.singUp(request));
+            userService.singUp(request);
+            return ResponseEntity.noContent().build();
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().build();
         }

--- a/back/src/main/java/KBT2/comunity/back/controller/UserController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/UserController.java
@@ -1,0 +1,77 @@
+package KBT2.comunity.back.controller;
+
+import KBT2.comunity.back.dto.TokenResponse;
+import KBT2.comunity.back.dto.User.*;
+import KBT2.comunity.back.service.UserService;
+import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<TokenResponse> signUp(@Valid @RequestBody UserCreateRequest request) {
+        try{
+            return ResponseEntity.ok(userService.singUp(request));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody UserLoginRequest request) {
+        try{
+            return ResponseEntity.ok(userService.login(request));
+        }
+        catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("")
+    public ResponseEntity<UserDto> getUser(@AuthenticationPrincipal UUID id) {
+        try {
+            System.out.println(id);
+            return ResponseEntity.ok(userService.getUser(id));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PatchMapping("")
+    public ResponseEntity<UserDto> updateUser(@AuthenticationPrincipal UUID id, @Valid @RequestBody UserUpdateRequest request) {
+        try {
+            return ResponseEntity.ok(userService.updateUser(id, request));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal UUID id, @Valid @RequestBody UserPasswordUpdateRequest request) {
+        try {
+            userService.updatePassword(id, request);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UUID id) {
+        try {
+            userService.deleteUser(id);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/controller/UserController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/UserController.java
@@ -22,70 +22,45 @@ public class UserController {
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@Valid @RequestBody UserCreateRequest request) {
-        try{
-            userService.singUp(request);
-            return ResponseEntity.ok().build();
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        userService.singUp(request);
+        return ResponseEntity.status(201).build();
     }
 
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@Valid @RequestBody UserLoginRequest request, HttpServletResponse response) {
-        try{
-            TokenDto tokenDto = userService.login(request);
+        TokenDto tokenDto = userService.login(request);
 
-            ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
-                    .httpOnly(true)
-                    .secure(false)
-                    .sameSite("Strict")
-                    .maxAge(60 * 60 * 24)
-                    .build();
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Strict")
+                .maxAge(60 * 60 * 24)
+                .build();
 
-            response.addHeader("Set-Cookie", cookie.toString());
-            return ResponseEntity.ok(new TokenResponse(tokenDto.getAccessToken()));
-        }
-        catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        response.addHeader("Set-Cookie", cookie.toString());
+        return ResponseEntity.ok(new TokenResponse(tokenDto.getAccessToken()));
     }
 
     @GetMapping("")
     public ResponseEntity<UserDto> getUser(@AuthenticationPrincipal UUID id) {
-        try {
-            System.out.println(id);
-            return ResponseEntity.ok(userService.getUser(id));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        System.out.println(id);
+        return ResponseEntity.ok(userService.getUser(id));
     }
 
     @PatchMapping("")
     public ResponseEntity<UserDto> updateUser(@AuthenticationPrincipal UUID id, @Valid @RequestBody UserUpdateRequest request) {
-        try {
-            return ResponseEntity.ok(userService.updateUser(id, request));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        return ResponseEntity.ok(userService.updateUser(id, request));
     }
 
     @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal UUID id, @Valid @RequestBody UserPasswordUpdateRequest request) {
-        try {
-            userService.updatePassword(id, request);
-            return ResponseEntity.ok().build();
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        userService.updatePassword(id, request);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("")
     public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UUID id) {
-        try {
-            userService.deleteUser(id);
-            return ResponseEntity.ok().build();
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        userService.deleteUser(id);
+        return ResponseEntity.ok().build();
     }
 }

--- a/back/src/main/java/KBT2/comunity/back/controller/UserController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<Void> signUp(@Valid @RequestBody UserCreateRequest request) {
+    public ResponseEntity<Void> signUp(@Valid @ModelAttribute UserCreateRequest request) {
         userService.singUp(request);
         return ResponseEntity.status(201).build();
     }
@@ -49,7 +49,7 @@ public class UserController {
     }
 
     @PatchMapping("")
-    public ResponseEntity<UserDto> updateUser(@AuthenticationPrincipal UUID id, @Valid @RequestBody UserUpdateRequest request) {
+    public ResponseEntity<UserDto> updateUser(@AuthenticationPrincipal UUID id, @Valid @ModelAttribute UserUpdateRequest request) {
         return ResponseEntity.ok(userService.updateUser(id, request));
     }
 

--- a/back/src/main/java/KBT2/comunity/back/controller/UserController.java
+++ b/back/src/main/java/KBT2/comunity/back/controller/UserController.java
@@ -5,8 +5,8 @@ import KBT2.comunity.back.dto.Token.TokenResponse;
 import KBT2.comunity.back.dto.User.*;
 import KBT2.comunity.back.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,14 +30,15 @@ public class UserController {
     public ResponseEntity<TokenResponse> login(@Valid @RequestBody UserLoginRequest request, HttpServletResponse response) {
         TokenDto tokenDto = userService.login(request);
 
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
                 .httpOnly(true)
-                .secure(false)
-                .sameSite("Strict")
+                .secure(true)
+                .sameSite("None")
                 .maxAge(60 * 60 * 24)
+                .path("/")
                 .build();
 
-        response.addHeader("Set-Cookie", cookie.toString());
+        response.setHeader("Set-Cookie", refreshTokenCookie.toString());
         return ResponseEntity.ok(new TokenResponse(tokenDto.getAccessToken()));
     }
 

--- a/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentCreateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentCreateRequest.java
@@ -1,0 +1,12 @@
+package KBT2.comunity.back.dto.Comment;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentCreateRequest {
+    private String content;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentDto.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentDto.java
@@ -1,0 +1,34 @@
+package KBT2.comunity.back.dto.Comment;
+
+import KBT2.comunity.back.entity.Comment;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NotNull
+@AllArgsConstructor
+@Builder
+public class CommentDto {
+    private UUID id;
+    private UUID postId;
+    private UUID userId;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static CommentDto fromEntity(Comment comment) {
+        return CommentDto.builder()
+                .id(comment.getId())
+                .postId(comment.getPost().getId())
+                .userId(comment.getUser().getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentDto.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentDto.java
@@ -19,6 +19,7 @@ public class CommentDto {
     private UUID id;
     private UUID postId;
     private UUID userId;
+    private CommentUserInfo userInfo;
     private String content;
     private LocalDateTime createdAt;
 
@@ -27,6 +28,9 @@ public class CommentDto {
                 .id(comment.getId())
                 .postId(comment.getPost().getId())
                 .userId(comment.getUser().getId())
+                .userInfo(CommentUserInfo.builder()
+                        .nickname(comment.getUser().getNickname())
+                        .logoImage(comment.getUser().getLogoImage()).build())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .build();

--- a/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentUserInfo.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Comment/CommentUserInfo.java
@@ -1,0 +1,15 @@
+package KBT2.comunity.back.dto.Comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class CommentUserInfo {
+    private String nickname;
+    private String logoImage;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/Post/PostCreateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Post/PostCreateRequest.java
@@ -1,0 +1,14 @@
+package KBT2.comunity.back.dto.Post;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostCreateRequest {
+    private String title;
+    private String content;
+    private String image;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/Post/PostCreateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Post/PostCreateRequest.java
@@ -1,6 +1,7 @@
 package KBT2.comunity.back.dto.Post;
 
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -10,5 +11,5 @@ import lombok.*;
 public class PostCreateRequest {
     private String title;
     private String content;
-    private String image;
+    private MultipartFile image;
 }

--- a/back/src/main/java/KBT2/comunity/back/dto/Post/PostDto.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Post/PostDto.java
@@ -1,0 +1,39 @@
+package KBT2.comunity.back.dto.Post;
+
+import KBT2.comunity.back.entity.Post;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostDto {
+    private UUID id;
+    private String title;
+    private String content;
+    private String image;
+    private String author;
+    private String authorImage;
+    private int likes;
+    private int views;
+    private String createdAt;
+    private String updatedAt;
+
+    public static PostDto fromEntity(Post post) {
+        return PostDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .image(post.getImage())
+                .author(post.getUser().getNickname())
+                .authorImage(post.getUser().getLogoImage())
+                .likes(post.getLikes())
+                .views(post.getViews())
+                .createdAt(post.getCreatedAt().toString())
+                .updatedAt(post.getUpdatedAt().toString())
+                .build();
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/Post/PostDto.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Post/PostDto.java
@@ -1,8 +1,12 @@
 package KBT2.comunity.back.dto.Post;
 
+import KBT2.comunity.back.dto.Comment.CommentDto;
+import KBT2.comunity.back.entity.Comment;
 import KBT2.comunity.back.entity.Post;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -19,6 +23,7 @@ public class PostDto {
     private String authorImage;
     private int likes;
     private int views;
+    private int comments;
     private String createdAt;
     private String updatedAt;
 
@@ -32,6 +37,7 @@ public class PostDto {
                 .authorImage(post.getUser().getLogoImage())
                 .likes(post.getLikes())
                 .views(post.getViews())
+                .comments(post.getComments().size())
                 .createdAt(post.getCreatedAt().toString())
                 .updatedAt(post.getUpdatedAt().toString())
                 .build();

--- a/back/src/main/java/KBT2/comunity/back/dto/Post/PostResponse.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Post/PostResponse.java
@@ -1,0 +1,14 @@
+package KBT2.comunity.back.dto.Post;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostResponse {
+    private UUID id;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/Response.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Response.java
@@ -1,4 +1,4 @@
-package KBT2.comunity.back.dto.Post;
+package KBT2.comunity.back.dto;
 
 import lombok.*;
 
@@ -9,6 +9,6 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class PostResponse {
+public class Response {
     private UUID id;
 }

--- a/back/src/main/java/KBT2/comunity/back/dto/Token/TokenDto.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Token/TokenDto.java
@@ -1,0 +1,13 @@
+package KBT2.comunity.back.dto.Token;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/Token/TokenResponse.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/Token/TokenResponse.java
@@ -1,4 +1,4 @@
-package KBT2.comunity.back.dto;
+package KBT2.comunity.back.dto.Token;
 
 import lombok.*;
 
@@ -9,5 +9,4 @@ import lombok.*;
 @Builder
 public class TokenResponse {
     private String accessToken;
-    private String refreshToken;
 }

--- a/back/src/main/java/KBT2/comunity/back/dto/TokenResponse.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/TokenResponse.java
@@ -1,0 +1,13 @@
+package KBT2.comunity.back.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserCreateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserCreateRequest.java
@@ -1,0 +1,29 @@
+package KBT2.comunity.back.dto.User;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserCreateRequest {
+
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Size(max = 25)
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 6, max = 20)
+    private String password;
+
+    @NotBlank(message = "닉네임을 입력하세요.")
+    @Size(max = 50)
+    private String nickname;
+
+    private String logoImage;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserCreateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -25,5 +26,5 @@ public class UserCreateRequest {
     @Size(max = 50)
     private String nickname;
 
-    private String logoImage;
+    private MultipartFile logoImage;
 }

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserDto.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserDto.java
@@ -1,0 +1,27 @@
+package KBT2.comunity.back.dto.User;
+
+import KBT2.comunity.back.entity.User;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDto {
+    private UUID id;
+    private String email;
+    private String nickname;
+    private String logoImage;
+
+    public static UserDto fromEntity(User user) {
+        return UserDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .logoImage(user.getLogoImage())
+                .build();
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserLoginRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserLoginRequest.java
@@ -1,0 +1,20 @@
+package KBT2.comunity.back.dto.User;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserLoginRequest {
+
+    @NotBlank(message = "이메일을 입력하세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 6, max = 20)
+    private String password;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserPasswordUpdateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserPasswordUpdateRequest.java
@@ -1,0 +1,20 @@
+package KBT2.comunity.back.dto.User;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserPasswordUpdateRequest {
+
+    @NotBlank(message = "현재 비밀번호를 입력하세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력하세요.")
+    @Size(min = 6, max = 20)
+    private String newPassword;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserPasswordUpdateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserPasswordUpdateRequest.java
@@ -10,10 +10,6 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class UserPasswordUpdateRequest {
-
-    @NotBlank(message = "현재 비밀번호를 입력하세요.")
-    private String currentPassword;
-
     @NotBlank(message = "새 비밀번호를 입력하세요.")
     @Size(min = 6, max = 20)
     private String newPassword;

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserUpdateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserUpdateRequest.java
@@ -1,0 +1,17 @@
+package KBT2.comunity.back.dto.User;
+
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserUpdateRequest {
+
+    @Size(max = 50)
+    private String nickname;
+
+    private String logoImage;
+}

--- a/back/src/main/java/KBT2/comunity/back/dto/User/UserUpdateRequest.java
+++ b/back/src/main/java/KBT2/comunity/back/dto/User/UserUpdateRequest.java
@@ -2,6 +2,7 @@ package KBT2.comunity.back.dto.User;
 
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -13,5 +14,5 @@ public class UserUpdateRequest {
     @Size(max = 50)
     private String nickname;
 
-    private String logoImage;
+    private MultipartFile logoImage;
 }

--- a/back/src/main/java/KBT2/comunity/back/entity/Comment.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/Comment.java
@@ -7,44 +7,31 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Entity
-@Table(name = "post")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "comment")
 @Where(clause = "is_deleted = false")
-public class Post {
+public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
-
-    @Column(nullable = false, length = 255)
-    private String title;
-
-    @Lob
     @Column(nullable = false)
     private String content;
-
-    private String image;
-
-    @Column(nullable = false)
-    private int likes = 0;
-
-    @Column(nullable = false)
-    private int views = 0;
 
     @Column(nullable = false)
     private boolean isDeleted = false;

--- a/back/src/main/java/KBT2/comunity/back/entity/Post.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/Post.java
@@ -1,0 +1,53 @@
+package KBT2.comunity.back.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "post")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Where(clause = "is_deleted = false")
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    private String image;
+
+    @Column(nullable = false)
+    private int likes = 0;
+
+    @Column(nullable = false)
+    private int views = 0;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+}

--- a/back/src/main/java/KBT2/comunity/back/entity/RefreshToken.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/RefreshToken.java
@@ -1,0 +1,30 @@
+package KBT2.comunity.back.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+}

--- a/back/src/main/java/KBT2/comunity/back/entity/User.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/User.java
@@ -24,13 +24,13 @@ public class User {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true, length = 25)
+    @Column(nullable = false, unique = true, length = 255)
     private String email;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 100)
     private String password;
 
-    @Column(nullable = false, length = 25)
+    @Column(nullable = false, length = 50)
     private String nickname;
 
     @Column(nullable = false, length = 255)

--- a/back/src/main/java/KBT2/comunity/back/entity/User.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/User.java
@@ -1,0 +1,45 @@
+package KBT2.comunity.back.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 25)
+    private String email;
+
+    @Column(nullable = false, length = 20)
+    private String password;
+
+    @Column(nullable = false, length = 25)
+    private String nickname;
+
+    @Column(nullable = false, length = 255)
+    private String logoImage;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted = false;
+
+    @UpdateTimestamp
+    @Column(nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @CreationTimestamp
+    @Column(nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+}

--- a/back/src/main/java/KBT2/comunity/back/entity/User.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/User.java
@@ -39,6 +39,9 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Post> posts = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean isDeleted = false;
 

--- a/back/src/main/java/KBT2/comunity/back/entity/User.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Where(clause = "is_deleted = false")
 public class User {
     @Id
     @GeneratedValue

--- a/back/src/main/java/KBT2/comunity/back/entity/User.java
+++ b/back/src/main/java/KBT2/comunity/back/entity/User.java
@@ -7,6 +7,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -19,7 +21,7 @@ import java.util.UUID;
 @Where(clause = "is_deleted = false")
 public class User {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(nullable = false, unique = true, length = 25)
@@ -33,6 +35,9 @@ public class User {
 
     @Column(nullable = false, length = 255)
     private String logoImage;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
 
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean isDeleted = false;

--- a/back/src/main/java/KBT2/comunity/back/exception/ErrorResponse.java
+++ b/back/src/main/java/KBT2/comunity/back/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package KBT2.comunity.back.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private int status;
+    private String message;
+    private List<String> details;
+
+    public ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+        this.details = Collections.emptyList();
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/KBT2/comunity/back/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package KBT2.comunity.back.exception;
+
+import KBT2.comunity.back.exception.code.ConflictException;
+import KBT2.comunity.back.exception.code.ForbiddenException;
+import KBT2.comunity.back.exception.code.NotFoundException;
+import KBT2.comunity.back.exception.code.UnauthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        List<String> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        return new ResponseEntity<>(new ErrorResponse(400, "잘못된 요청입니다.", errors), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException ex) {
+        return new ResponseEntity<>(new ErrorResponse(401, ex.getMessage()), HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException ex) {
+        return new ResponseEntity<>(new ErrorResponse(403, ex.getMessage()), HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
+        return new ResponseEntity<>(new ErrorResponse(404, ex.getMessage()), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> handleConflictException(ConflictException ex) {
+        return new ResponseEntity<>(new ErrorResponse(409, ex.getMessage()), HttpStatus.CONFLICT);
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
+        return new ResponseEntity<>(new ErrorResponse(500, "서버 내부 오류가 발생했습니다."), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/exception/code/ConflictException.java
+++ b/back/src/main/java/KBT2/comunity/back/exception/code/ConflictException.java
@@ -1,0 +1,11 @@
+package KBT2.comunity.back.exception.code;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/exception/code/ForbiddenException.java
+++ b/back/src/main/java/KBT2/comunity/back/exception/code/ForbiddenException.java
@@ -1,0 +1,11 @@
+package KBT2.comunity.back.exception.code;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/exception/code/NotFoundException.java
+++ b/back/src/main/java/KBT2/comunity/back/exception/code/NotFoundException.java
@@ -1,0 +1,11 @@
+package KBT2.comunity.back.exception.code;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/exception/code/UnauthorizedException.java
+++ b/back/src/main/java/KBT2/comunity/back/exception/code/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package KBT2.comunity.back.exception.code;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import org.springframework.security.core.AuthenticationException;
+
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedException extends AuthenticationException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/exception/message/ErrorMessage.java
+++ b/back/src/main/java/KBT2/comunity/back/exception/message/ErrorMessage.java
@@ -1,0 +1,19 @@
+package KBT2.comunity.back.exception.message;
+
+public class ErrorMessage {
+    public final static String INVALID_REQUEST = "잘못된 요청입니다.";
+    public final static String UNAUTHORIZED = "인증되지 않은 사용자입니다.";
+    public final static String FORBIDDEN = "권한이 없습니다.";
+    public final static String NOT_FOUND = "찾을 수 없는 리소스입니다.";
+    public final static String INTERNAL_SERVER_ERROR = "서버 내부 오류가 발생했습니다.";
+    public final static String CONFLICT = "이미 존재하는 리소스입니다.";
+
+    // Token Error
+    public final static String Token_NOT_FOUND = "토큰이 존재하지 않습니다.";
+    public final static String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
+
+    public final static String EMAIL_ALREADY_EXISTS = "이미 존재하는 이메일입니다.";
+    public final static String NICKNAME_ALREADY_EXISTS = "이미 존재하는 닉네임입니다.";
+    public final static String EMAIL_NOT_FOUND = "존재하지 않는 이메일입니다.";
+    public final static String USER_NOT_FOUND = "존재하지 않는 유저입니다.";
+}

--- a/back/src/main/java/KBT2/comunity/back/repository/CommentRepository.java
+++ b/back/src/main/java/KBT2/comunity/back/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package KBT2.comunity.back.repository;
+
+import KBT2.comunity.back.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CommentRepository extends JpaRepository<Comment, UUID> {
+    List<Comment> findAllByPostId(UUID postId);
+}

--- a/back/src/main/java/KBT2/comunity/back/repository/PostRepository.java
+++ b/back/src/main/java/KBT2/comunity/back/repository/PostRepository.java
@@ -4,9 +4,8 @@ import KBT2.comunity.back.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
-public interface PostRepositroy extends JpaRepository<Post, UUID> {
+public interface PostRepository extends JpaRepository<Post, UUID> {
     List<Post> findAllByUserId(UUID userId);
 }

--- a/back/src/main/java/KBT2/comunity/back/repository/PostRepository.java
+++ b/back/src/main/java/KBT2/comunity/back/repository/PostRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface PostRepository extends JpaRepository<Post, UUID> {
-    List<Post> findAllByUserId(UUID userId);
+    List<Post> findAllByOrderByUpdatedAtDesc();
 }

--- a/back/src/main/java/KBT2/comunity/back/repository/PostRepositroy.java
+++ b/back/src/main/java/KBT2/comunity/back/repository/PostRepositroy.java
@@ -1,0 +1,12 @@
+package KBT2.comunity.back.repository;
+
+import KBT2.comunity.back.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PostRepositroy extends JpaRepository<Post, UUID> {
+    List<Post> findAllByUserId(UUID userId);
+}

--- a/back/src/main/java/KBT2/comunity/back/repository/RefreshTokenRepository.java
+++ b/back/src/main/java/KBT2/comunity/back/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package KBT2.comunity.back.repository;
+
+import KBT2.comunity.back.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByToken(String token);
+}

--- a/back/src/main/java/KBT2/comunity/back/repository/RefreshTokenRepository.java
+++ b/back/src/main/java/KBT2/comunity/back/repository/RefreshTokenRepository.java
@@ -8,5 +8,6 @@ import java.util.UUID;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
     Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUserId(UUID userId);
     void deleteByToken(String token);
 }

--- a/back/src/main/java/KBT2/comunity/back/repository/UserRepository.java
+++ b/back/src/main/java/KBT2/comunity/back/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package KBT2.comunity.back.repository;
+
+import KBT2.comunity.back.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickname);
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+}

--- a/back/src/main/java/KBT2/comunity/back/service/CommentService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/CommentService.java
@@ -1,0 +1,74 @@
+package KBT2.comunity.back.service;
+
+import KBT2.comunity.back.dto.Comment.CommentCreateRequest;
+import KBT2.comunity.back.dto.Comment.CommentDto;
+import KBT2.comunity.back.dto.Response;
+import KBT2.comunity.back.entity.Comment;
+import KBT2.comunity.back.entity.Post;
+import KBT2.comunity.back.entity.User;
+import KBT2.comunity.back.exception.code.NotFoundException;
+import KBT2.comunity.back.repository.CommentRepository;
+import KBT2.comunity.back.repository.PostRepository;
+import KBT2.comunity.back.util.message.ErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public Response createComment(UUID postId, CommentCreateRequest request) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
+        User user = post.getUser();
+
+        Comment comment = Comment.builder()
+                .post(post)
+                .content(request.getContent())
+                .user(user)
+                .build();
+
+        commentRepository.save(comment);
+        post.getComments().add(comment);
+        user.getComments().add(comment);
+
+        return new Response(comment.getId());
+    }
+    public List<CommentDto> getCommentList(UUID postId) {
+        return commentRepository.findAllByPostId(postId)
+                .stream()
+                .map(CommentDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+    public CommentDto getComment(UUID commentId) {
+        return CommentDto.fromEntity(commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND)));
+    }
+    @Transactional
+    public CommentDto updateComment(UUID commentId, CommentCreateRequest request) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND));
+
+        if (request.getContent() != null) {
+            comment.setContent(request.getContent());
+        }
+
+        commentRepository.save(comment);
+        return CommentDto.fromEntity(comment);
+    }
+    @Transactional
+    public void deleteComment(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND));
+
+        comment.setDeleted(true);
+        commentRepository.save(comment);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/service/ImageUploadService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/ImageUploadService.java
@@ -1,0 +1,43 @@
+package KBT2.comunity.back.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Map;
+
+@Service
+public class ImageUploadService {
+    @Value("${imgbb.api.key}")
+    private String imgbbApiKey;
+
+    public String uploadToImgbb(MultipartFile file) throws IOException {
+        String url = "https://api.imgbb.com/1/upload?key=" + imgbbApiKey;
+
+        String base64Image = Base64.getEncoder().encodeToString(file.getBytes());
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("image", base64Image);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<Map> response = restTemplate.postForEntity(url, requestEntity, Map.class);
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            Map data = (Map) response.getBody().get("data");
+            return (String) data.get("url");
+        } else {
+            throw new RuntimeException("imgbb 업로드 실패");
+        }
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/service/PostService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/PostService.java
@@ -1,0 +1,81 @@
+package KBT2.comunity.back.service;
+
+import KBT2.comunity.back.dto.Post.PostCreateRequest;
+import KBT2.comunity.back.dto.Post.PostDto;
+import KBT2.comunity.back.dto.Post.PostResponse;
+import KBT2.comunity.back.entity.Post;
+import KBT2.comunity.back.entity.User;
+import KBT2.comunity.back.exception.code.NotFoundException;
+import KBT2.comunity.back.util.message.ErrorMessage;
+import KBT2.comunity.back.repository.PostRepositroy;
+import KBT2.comunity.back.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepositroy postRepository;
+    private final UserRepository userRepository;
+
+    public PostResponse createPost(UUID userId, PostCreateRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
+
+        Post post = Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .user(user)
+                .image(request.getImage())
+                .build();
+
+        postRepository.save(post);
+        return new PostResponse(post.getId());
+    }
+    public List<PostDto> getPostList(UUID userId) {
+        return postRepository.findAllByUserId(userId).stream().map(PostDto::fromEntity).collect(Collectors.toList());
+    }
+    @Transactional
+    public PostDto getPost(UUID postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
+
+        post.setViews(post.getViews() + 1);
+        postRepository.save(post);
+
+        return PostDto.fromEntity(post);
+    }
+    @Transactional
+    public PostDto updatePost(UUID postId, PostCreateRequest request) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
+
+        if (request.getTitle() != null) {
+            post.setTitle(request.getTitle());
+        }
+        if (request.getContent() != null) {
+            post.setContent(request.getContent());
+        }
+        if (request.getImage() != null) {
+            post.setImage(request.getImage());
+        }
+        postRepository.save(post);
+
+        return PostDto.fromEntity(post);
+    }
+    @Transactional
+    public void addLike(UUID postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
+        post.setLikes(post.getLikes() + 1);
+        postRepository.save(post);
+    }
+    @Transactional
+    public void deletePost(UUID postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
+
+        post.setDeleted(true);
+        postRepository.save(post);
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/service/PostService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/PostService.java
@@ -2,12 +2,12 @@ package KBT2.comunity.back.service;
 
 import KBT2.comunity.back.dto.Post.PostCreateRequest;
 import KBT2.comunity.back.dto.Post.PostDto;
-import KBT2.comunity.back.dto.Post.PostResponse;
+import KBT2.comunity.back.dto.Response;
 import KBT2.comunity.back.entity.Post;
 import KBT2.comunity.back.entity.User;
 import KBT2.comunity.back.exception.code.NotFoundException;
 import KBT2.comunity.back.util.message.ErrorMessage;
-import KBT2.comunity.back.repository.PostRepositroy;
+import KBT2.comunity.back.repository.PostRepository;
 import KBT2.comunity.back.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,10 +20,10 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class PostService {
-    private final PostRepositroy postRepository;
+    private final PostRepository postRepository;
     private final UserRepository userRepository;
 
-    public PostResponse createPost(UUID userId, PostCreateRequest request) {
+    public Response createPost(UUID userId, PostCreateRequest request) {
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
 
         Post post = Post.builder()
@@ -35,7 +35,7 @@ public class PostService {
 
         postRepository.save(post);
         user.getPosts().add(post);
-        return new PostResponse(post.getId());
+        return new Response(post.getId());
     }
     public List<PostDto> getPostList(UUID userId) {
         return postRepository.findAllByUserId(userId).stream().map(PostDto::fromEntity).collect(Collectors.toList());

--- a/back/src/main/java/KBT2/comunity/back/service/PostService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/PostService.java
@@ -34,6 +34,7 @@ public class PostService {
                 .build();
 
         postRepository.save(post);
+        user.getPosts().add(post);
         return new PostResponse(post.getId());
     }
     public List<PostDto> getPostList(UUID userId) {

--- a/back/src/main/java/KBT2/comunity/back/service/PostService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/PostService.java
@@ -6,9 +6,9 @@ import KBT2.comunity.back.dto.Response;
 import KBT2.comunity.back.entity.Post;
 import KBT2.comunity.back.entity.User;
 import KBT2.comunity.back.exception.code.NotFoundException;
-import KBT2.comunity.back.util.message.ErrorMessage;
 import KBT2.comunity.back.repository.PostRepository;
 import KBT2.comunity.back.repository.UserRepository;
+import KBT2.comunity.back.util.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,9 +37,11 @@ public class PostService {
         user.getPosts().add(post);
         return new Response(post.getId());
     }
-    public List<PostDto> getPostList(UUID userId) {
-        return postRepository.findAllByUserId(userId).stream().map(PostDto::fromEntity).collect(Collectors.toList());
+
+    public List<PostDto> getPostList() {
+        return postRepository.findAllByOrderByUpdatedAtDesc().stream().map(PostDto::fromEntity).collect(Collectors.toList());
     }
+
     @Transactional
     public PostDto getPost(UUID postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
@@ -49,6 +51,7 @@ public class PostService {
 
         return PostDto.fromEntity(post);
     }
+
     @Transactional
     public PostDto updatePost(UUID postId, PostCreateRequest request) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
@@ -66,12 +69,14 @@ public class PostService {
 
         return PostDto.fromEntity(post);
     }
+
     @Transactional
     public void addLike(UUID postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));
         post.setLikes(post.getLikes() + 1);
         postRepository.save(post);
     }
+
     @Transactional
     public void deletePost(UUID postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND));

--- a/back/src/main/java/KBT2/comunity/back/service/PostService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/PostService.java
@@ -12,7 +12,9 @@ import KBT2.comunity.back.util.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -22,15 +24,26 @@ import java.util.stream.Collectors;
 public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final ImageUploadService imageUploadService;
 
     public Response createPost(UUID userId, PostCreateRequest request) {
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
+
+        String imageUrl = null;
+        MultipartFile logoImageFile = request.getImage();
+        if (request.getImage() != null && !logoImageFile.isEmpty()) {
+            try {
+                imageUrl = imageUploadService.uploadToImgbb(logoImageFile);
+            } catch (IOException e) {
+                throw new RuntimeException("이미지 업로드 실패", e);
+            }
+        }
 
         Post post = Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .user(user)
-                .image(request.getImage())
+                .image(imageUrl)
                 .build();
 
         postRepository.save(post);
@@ -63,7 +76,16 @@ public class PostService {
             post.setContent(request.getContent());
         }
         if (request.getImage() != null) {
-            post.setImage(request.getImage());
+            String imageUrl = null;
+            MultipartFile logoImageFile = request.getImage();
+            if (!logoImageFile.isEmpty()) {
+                try {
+                    imageUrl = imageUploadService.uploadToImgbb(logoImageFile);
+                } catch (IOException e) {
+                    throw new RuntimeException("이미지 업로드 실패", e);
+                }
+            }
+            post.setImage(imageUrl);
         }
         postRepository.save(post);
 

--- a/back/src/main/java/KBT2/comunity/back/service/TokenService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/TokenService.java
@@ -1,0 +1,52 @@
+package KBT2.comunity.back.service;
+
+import KBT2.comunity.back.config.jwt.JwtUtil;
+import KBT2.comunity.back.dto.TokenResponse;
+import KBT2.comunity.back.entity.RefreshToken;
+import KBT2.comunity.back.entity.User;
+import KBT2.comunity.back.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenResponse generateTokens(User user) {
+        String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail());
+
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(user.getId());
+
+        String refreshToken = existingToken
+                .filter(token -> jwtUtil.validateToken(token.getToken()))
+                .map(RefreshToken::getToken)
+                .orElseGet(() -> {
+                    String newToken = jwtUtil.createRefreshToken(user.getId(), user.getEmail());
+                    saveOrUpdateRefreshToken(user, newToken);
+                    return newToken;
+                });
+
+        return new TokenResponse(accessToken, refreshToken);
+    }
+    public void saveOrUpdateRefreshToken(User user, String refreshToken) {
+        refreshTokenRepository.findByUserId(user.getId())
+                .ifPresentOrElse(
+                        existingToken -> {
+                            existingToken.setToken(refreshToken);
+                            existingToken.setExpiryDate(java.time.LocalDateTime.now().plusDays(7));
+                            refreshTokenRepository.save(existingToken);
+                        },
+                        () -> {
+                            refreshTokenRepository.save(RefreshToken.builder()
+                                    .user(user)
+                                    .token(refreshToken)
+                                    .expiryDate(java.time.LocalDateTime.now().plusDays(7))
+                                    .build());
+                        }
+                );
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/service/TokenService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/TokenService.java
@@ -1,7 +1,7 @@
 package KBT2.comunity.back.service;
 
 import KBT2.comunity.back.config.jwt.JwtUtil;
-import KBT2.comunity.back.dto.TokenResponse;
+import KBT2.comunity.back.dto.Token.TokenDto;
 import KBT2.comunity.back.entity.RefreshToken;
 import KBT2.comunity.back.entity.User;
 import KBT2.comunity.back.repository.RefreshTokenRepository;
@@ -16,7 +16,7 @@ public class TokenService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public TokenResponse generateTokens(User user) {
+    public TokenDto generateTokens(User user) {
         String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail());
 
         Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(user.getId());
@@ -24,29 +24,29 @@ public class TokenService {
         String refreshToken = existingToken
                 .filter(token -> jwtUtil.validateToken(token.getToken()))
                 .map(RefreshToken::getToken)
-                .orElseGet(() -> {
-                    String newToken = jwtUtil.createRefreshToken(user.getId(), user.getEmail());
-                    saveOrUpdateRefreshToken(user, newToken);
-                    return newToken;
-                });
+                .orElseGet(() -> createAndSaveRefreshToken(user));
 
-        return new TokenResponse(accessToken, refreshToken);
+        return new TokenDto(accessToken, refreshToken);
+    }
+    private String createAndSaveRefreshToken(User user) {
+        String newToken = jwtUtil.createRefreshToken(user.getId(), user.getEmail());
+        saveOrUpdateRefreshToken(user, newToken);
+        return newToken;
     }
     public void saveOrUpdateRefreshToken(User user, String refreshToken) {
         refreshTokenRepository.findByUserId(user.getId())
                 .ifPresentOrElse(
                         existingToken -> {
                             existingToken.setToken(refreshToken);
-                            existingToken.setExpiryDate(java.time.LocalDateTime.now().plusDays(7));
+                            existingToken.setExpiryDate(java.time.LocalDateTime.now().plusDays(1));
                             refreshTokenRepository.save(existingToken);
                         },
-                        () -> {
-                            refreshTokenRepository.save(RefreshToken.builder()
-                                    .user(user)
-                                    .token(refreshToken)
-                                    .expiryDate(java.time.LocalDateTime.now().plusDays(7))
-                                    .build());
-                        }
+                        () -> refreshTokenRepository.save(
+                                RefreshToken.builder()
+                                        .user(user)
+                                        .token(refreshToken)
+                                        .expiryDate(java.time.LocalDateTime.now().plusDays(7))
+                                        .build())
                 );
     }
 }

--- a/back/src/main/java/KBT2/comunity/back/service/TokenService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/TokenService.java
@@ -21,10 +21,14 @@ public class TokenService {
 
         Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(user.getId());
 
-        String refreshToken = existingToken
-                .filter(token -> jwtUtil.validateToken(token.getToken()))
-                .map(RefreshToken::getToken)
-                .orElseGet(() -> createAndSaveRefreshToken(user));
+        String refreshToken = existingToken.map(token -> {
+            try{
+                jwtUtil.validateToken(token.getToken());
+                return token.getToken();
+            } catch (Exception e) {
+                return createAndSaveRefreshToken(user);
+            }
+        }).orElseGet(() -> createAndSaveRefreshToken(user));
 
         return new TokenDto(accessToken, refreshToken);
     }

--- a/back/src/main/java/KBT2/comunity/back/service/UserService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/UserService.java
@@ -1,11 +1,8 @@
 package KBT2.comunity.back.service;
 
-import KBT2.comunity.back.config.jwt.JwtUtil;
-import KBT2.comunity.back.dto.TokenResponse;
+import KBT2.comunity.back.dto.Token.TokenDto;
 import KBT2.comunity.back.dto.User.*;
-import KBT2.comunity.back.entity.RefreshToken;
 import KBT2.comunity.back.entity.User;
-import KBT2.comunity.back.repository.RefreshTokenRepository;
 import KBT2.comunity.back.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +34,7 @@ public class UserService {
         userRepository.save(user);
     }
 
-    public TokenResponse login(UserLoginRequest request) {
+    public TokenDto login(UserLoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
         return tokenService.generateTokens(user);

--- a/back/src/main/java/KBT2/comunity/back/service/UserService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/UserService.java
@@ -3,6 +3,9 @@ package KBT2.comunity.back.service;
 import KBT2.comunity.back.dto.Token.TokenDto;
 import KBT2.comunity.back.dto.User.*;
 import KBT2.comunity.back.entity.User;
+import KBT2.comunity.back.exception.code.ConflictException;
+import KBT2.comunity.back.exception.code.NotFoundException;
+import KBT2.comunity.back.exception.message.ErrorMessage;
 import KBT2.comunity.back.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +23,9 @@ public class UserService {
     @Transactional
     public void singUp(UserCreateRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+            throw new ConflictException(ErrorMessage.EMAIL_ALREADY_EXISTS);
         } else if (userRepository.existsByNickname(request.getNickname())) {
-            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+            throw new ConflictException(ErrorMessage.NICKNAME_ALREADY_EXISTS);
         }
         User user = User.builder()
                 .email(request.getEmail())
@@ -36,25 +39,25 @@ public class UserService {
 
     public TokenDto login(UserLoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         return tokenService.generateTokens(user);
     }
 
     public UserDto getUser(UUID id){
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         return UserDto.fromEntity(user);
     }
 
     @Transactional
     public UserDto updateUser(UUID userId, UserUpdateRequest request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
         if (request.getNickname() != null && !request.getNickname().isEmpty()) {
             Optional<User> existingUser = userRepository.findByNickname(request.getNickname());
             if (existingUser.isPresent() && !existingUser.get().getId().equals(userId)) {
-                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+                throw new ConflictException(ErrorMessage.NICKNAME_ALREADY_EXISTS);
             }
             user.setNickname(request.getNickname());
         }
@@ -69,7 +72,7 @@ public class UserService {
     @Transactional
     public void updatePassword(UUID userId, UserPasswordUpdateRequest request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
         user.setPassword(request.getNewPassword());
     }
@@ -77,7 +80,7 @@ public class UserService {
     @Transactional
     public void deleteUser(UUID userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         user.setDeleted(true);
     }
 }

--- a/back/src/main/java/KBT2/comunity/back/service/UserService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/UserService.java
@@ -5,7 +5,7 @@ import KBT2.comunity.back.dto.User.*;
 import KBT2.comunity.back.entity.User;
 import KBT2.comunity.back.exception.code.ConflictException;
 import KBT2.comunity.back.exception.code.NotFoundException;
-import KBT2.comunity.back.exception.message.ErrorMessage;
+import KBT2.comunity.back.util.message.ErrorMessage;
 import KBT2.comunity.back.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/back/src/main/java/KBT2/comunity/back/service/UserService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/UserService.java
@@ -1,0 +1,111 @@
+package KBT2.comunity.back.service;
+
+import KBT2.comunity.back.config.jwt.JwtUtil;
+import KBT2.comunity.back.dto.TokenResponse;
+import KBT2.comunity.back.dto.User.*;
+import KBT2.comunity.back.entity.RefreshToken;
+import KBT2.comunity.back.entity.User;
+import KBT2.comunity.back.repository.RefreshTokenRepository;
+import KBT2.comunity.back.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public TokenResponse singUp(UserCreateRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        } else if (userRepository.existsByNickname(request.getNickname())) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .nickname(request.getNickname())
+                .logoImage(request.getLogoImage())
+                .build();
+
+        userRepository.save(user);
+        return generateTokens(user);
+    }
+
+    public TokenResponse login(UserLoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+        return generateTokens(user);
+    }
+
+    public UserDto getUser(UUID id){
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+        return UserDto.fromEntity(user);
+    }
+
+    @Transactional
+    public UserDto updateUser(UUID userId, UserUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (request.getNickname() != null && !request.getNickname().isEmpty()) {
+            Optional<User> existingUser = userRepository.findByNickname(request.getNickname());
+            if (existingUser.isPresent() && !existingUser.get().getId().equals(userId)) {
+                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            }
+            user.setNickname(request.getNickname());
+        }
+
+        if (request.getLogoImage() != null) {
+            user.setLogoImage(request.getLogoImage());
+        }
+
+        return UserDto.fromEntity(user);
+    }
+
+    @Transactional
+    public void updatePassword(UUID userId, UserPasswordUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        user.setPassword(request.getNewPassword());
+    }
+
+    @Transactional
+    public void deleteUser(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.setDeleted(true);
+    }
+
+    private TokenResponse generateTokens(User user) {
+        String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail());
+
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findById(user.getId());
+        String refreshToken = existingToken.map(RefreshToken::getToken)
+                .orElseGet(() -> {
+                    String newToken = jwtUtil.createRefreshToken(user.getId(), user.getEmail());
+                    saveRefreshToken(user, newToken);
+                    return newToken;
+                });
+
+        return new TokenResponse(accessToken, refreshToken);
+    }
+    private void saveRefreshToken(User user, String refreshToken) {
+        refreshTokenRepository.deleteByToken(refreshToken);
+
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(user)
+                .token(refreshToken)
+                .expiryDate(java.time.LocalDateTime.now().plusDays(7))
+                .build());
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/service/UserService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/UserService.java
@@ -6,8 +6,8 @@ import KBT2.comunity.back.entity.User;
 import KBT2.comunity.back.exception.code.ConflictException;
 import KBT2.comunity.back.exception.code.NotFoundException;
 import KBT2.comunity.back.exception.code.UnauthorizedException;
-import KBT2.comunity.back.util.message.ErrorMessage;
 import KBT2.comunity.back.repository.UserRepository;
+import KBT2.comunity.back.util.message.ErrorMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -54,7 +54,7 @@ public class UserService {
         return tokenService.generateTokens(user);
     }
 
-    public UserDto getUser(UUID id){
+    public UserDto getUser(UUID id) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         return UserDto.fromEntity(user);
@@ -85,7 +85,9 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
-        user.setPassword(request.getNewPassword());
+        String encodedPassword = passwordEncoder.encode(request.getNewPassword());
+
+        user.setPassword(encodedPassword);
     }
 
     @Transactional

--- a/back/src/main/java/KBT2/comunity/back/service/UserService.java
+++ b/back/src/main/java/KBT2/comunity/back/service/UserService.java
@@ -12,7 +12,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,9 +24,11 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenService tokenService;
+    private final ImageUploadService imageUploadService;
 
     @Transactional
     public void singUp(UserCreateRequest request) {
+        System.out.println(request);
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new ConflictException(ErrorMessage.EMAIL_ALREADY_EXISTS);
         } else if (userRepository.existsByNickname(request.getNickname())) {
@@ -32,12 +36,21 @@ public class UserService {
         }
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
+        String imageUrl = null;
+        MultipartFile logoImageFile = request.getLogoImage();
+        if (logoImageFile != null && !logoImageFile.isEmpty()) {
+            try {
+                imageUrl = imageUploadService.uploadToImgbb(logoImageFile);
+            } catch (IOException e) {
+                throw new RuntimeException("이미지 업로드 실패", e);
+            }
+        }
 
         User user = User.builder()
                 .email(request.getEmail())
                 .password(encodedPassword)
                 .nickname(request.getNickname())
-                .logoImage(request.getLogoImage())
+                .logoImage(imageUrl)
                 .build();
 
         userRepository.save(user);
@@ -74,9 +87,20 @@ public class UserService {
         }
 
         if (request.getLogoImage() != null) {
-            user.setLogoImage(request.getLogoImage());
-        }
+            String imageUrl = null;
+            MultipartFile logoImageFile = request.getLogoImage();
+            if (!logoImageFile.isEmpty()) {
+                try {
+                    imageUrl = imageUploadService.uploadToImgbb(logoImageFile);
+                } catch (IOException e) {
+                    throw new RuntimeException("이미지 업로드 실패", e);
+                }
+            }
+            System.out.println(imageUrl);
 
+            user.setLogoImage(imageUrl);
+        }
+        userRepository.save(user);
         return UserDto.fromEntity(user);
     }
 
@@ -88,6 +112,7 @@ public class UserService {
         String encodedPassword = passwordEncoder.encode(request.getNewPassword());
 
         user.setPassword(encodedPassword);
+        userRepository.save(user);
     }
 
     @Transactional
@@ -95,5 +120,6 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         user.setDeleted(true);
+        userRepository.save(user);
     }
 }

--- a/back/src/main/java/KBT2/comunity/back/util/ApiResponse.java
+++ b/back/src/main/java/KBT2/comunity/back/util/ApiResponse.java
@@ -1,0 +1,30 @@
+package KBT2.comunity.back.util;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ApiResponse<T> {
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return ApiResponse.<T>builder()
+                .message(message)
+                .data(data)
+                .build();
+    }
+    public static <T> ApiResponse<T> ok(String message) {
+        return ApiResponse.<T>builder()
+                .message(message)
+                .build();
+    }
+    public static <T> ApiResponse<T> ok(T data) {
+        return ApiResponse.<T>builder()
+                .data(data)
+                .build();
+    }
+}

--- a/back/src/main/java/KBT2/comunity/back/util/message/ErrorMessage.java
+++ b/back/src/main/java/KBT2/comunity/back/util/message/ErrorMessage.java
@@ -15,6 +15,7 @@ public class ErrorMessage {
     // User Error
     public final static String EMAIL_ALREADY_EXISTS = "이미 존재하는 이메일입니다.";
     public final static String NICKNAME_ALREADY_EXISTS = "이미 존재하는 닉네임입니다.";
+    public final static String INVALID_PASSWORD = "비밀번호가 일치하지 않습니다.";
     public final static String EMAIL_NOT_FOUND = "존재하지 않는 이메일입니다.";
     public final static String USER_NOT_FOUND = "존재하지 않는 유저입니다.";
 

--- a/back/src/main/java/KBT2/comunity/back/util/message/ErrorMessage.java
+++ b/back/src/main/java/KBT2/comunity/back/util/message/ErrorMessage.java
@@ -20,4 +20,7 @@ public class ErrorMessage {
 
     // Post Error
     public final static String POST_NOT_FOUND = "존재하지 않는 게시글입니다.";
+
+    // Comment Error
+    public final static String COMMENT_NOT_FOUND = "존재하지 않는 댓글입니다.";
 }

--- a/back/src/main/java/KBT2/comunity/back/util/message/ErrorMessage.java
+++ b/back/src/main/java/KBT2/comunity/back/util/message/ErrorMessage.java
@@ -1,4 +1,4 @@
-package KBT2.comunity.back.exception.message;
+package KBT2.comunity.back.util.message;
 
 public class ErrorMessage {
     public final static String INVALID_REQUEST = "잘못된 요청입니다.";
@@ -12,8 +12,12 @@ public class ErrorMessage {
     public final static String Token_NOT_FOUND = "토큰이 존재하지 않습니다.";
     public final static String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 
+    // User Error
     public final static String EMAIL_ALREADY_EXISTS = "이미 존재하는 이메일입니다.";
     public final static String NICKNAME_ALREADY_EXISTS = "이미 존재하는 닉네임입니다.";
     public final static String EMAIL_NOT_FOUND = "존재하지 않는 이메일입니다.";
     public final static String USER_NOT_FOUND = "존재하지 않는 유저입니다.";
+
+    // Post Error
+    public final static String POST_NOT_FOUND = "존재하지 않는 게시글입니다.";
 }

--- a/back/src/main/java/KBT2/comunity/back/util/message/SuccessMessage.java
+++ b/back/src/main/java/KBT2/comunity/back/util/message/SuccessMessage.java
@@ -1,0 +1,8 @@
+package KBT2.comunity.back.util.message;
+
+public class SuccessMessage {
+    public final static String FIND_SUCCESS = "조회 성공";
+    public final static String POST_SUCCESS = "삽입 성공";
+    public final static String PATCH_SUCCESS = "수정 성공";
+    public final static String DELETE_SUCCESS = "삭제 성공";
+}

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=back

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: KBT-comunity
+  config:
+    import: optional:application-secret.yml
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+springdoc:
+  swagger-ui:
+    path: /
+  api-docs:
+    path: /v3/api-docs

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -6,10 +6,19 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 springdoc:
   swagger-ui:
     path: /
   api-docs:
     path: /v3/api-docs
+logging:
+  level:
+    org.springframework.web: DEBUG
+    org.springframework.security: DEBUG
+    org.springframework.boot.actuate: DEBUG
+

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -8,9 +8,6 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
 springdoc:
   swagger-ui:
     path: /

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -6,11 +6,11 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 springdoc:
   swagger-ui:
-    path: /
+    path: /swagger-ui.html
   api-docs:
     path: /v3/api-docs
 logging:

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     name: KBT-comunity
   config:
     import: optional:application-secret.yml
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:

--- a/back/src/test/java/KBT2/comunity/back/BackApplicationTests.java
+++ b/back/src/test/java/KBT2/comunity/back/BackApplicationTests.java
@@ -1,4 +1,4 @@
-package com.example.back;
+package KBT2.comunity.back;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## "아무 말 대잔치" 커뮤니티 백엔드 REST API 개발 완료

#1 
- jwtFilterChain
- User CRUD
- Post CRUD
- Comment CRUD

### 1. JwtFilterChain
- Authorization 토큰이 필요없는 특정 api를 제외하고는 검사과정을 통해 accessToken으로 유저를 찾고, user가 존재할 경우에만 동작하도록 개발.
- 추후, 사용자별 권한설정의 경우 추가 설계 진행 가능

### 2. 회원가입 / 로그인
- 로그인 시 accessToken만 전달하고, refreshToken은 HttpOnly속성 쿠키로 전달. accessToken의 만료시간을 짧게 설정해, 만료되면 전달해준 refreshToken으로 재발급 가능.

### 3. Token API 구현
- accessToken이 만료되었을 경우, HttpOnly 속성의 refreshToken을 받아. accessToken만 재발급 진행하도록 구성.

### 4. User
- 로그인, 회원가입, 유저 조회, 유저 수정, 비밀번호 변경, 회원가입 탈퇴 구현
- email, nickname은 유니크로 중복값 제외.
- 삭제의 경우 soft 삭제로 isDeleted값으로 조절
- 추후, 유저 복원기능을 통해 삭제를 롤백 기능 추가 가능

### 5. Post
- 모든 게시글 조회(변경 시간 DESC), 단일 게시글 조회, 게시글 수정, 게시글 삭제 구현
- 게시글도 soft 삭제로 isDeleted 조절

### 6. Comment
- 특정 게시글의 모든 댓글 조회, 단일 댓글 조회, 댓글 수정, 댓글 삭제 구현
- 삭제는 soft 삭제로 진행
- 추후, 댓글의 대댓글을 통해 댓글에서 대화가 가능하도록 개선 가능